### PR TITLE
STEP17 :: docker 이용하여 카프카 연동 및 테스트

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -46,6 +46,8 @@ dependencies {
 	testImplementation("org.springframework.boot:spring-boot-testcontainers")
 	testImplementation("org.testcontainers:junit-jupiter")
 	testImplementation("org.testcontainers:mysql")
+	testImplementation("org.testcontainers:kafka")
+	testImplementation("org.springframework.kafka:spring-kafka-test")
 	testRuntimeOnly("org.junit.platform:junit-platform-launcher")
 
 	//Rediss
@@ -53,7 +55,8 @@ dependencies {
 	implementation("org.springframework.boot:spring-boot-starter-data-redis")
 	// swagger
 	implementation("org.springdoc:springdoc-openapi-starter-webmvc-ui:2.7.0")
-
+	//kafka
+	implementation("org.springframework.kafka:spring-kafka")
 	// QueryDSL
 	implementation("com.querydsl:querydsl-jpa:5.0.0:jakarta")
 	annotationProcessor("com.querydsl:querydsl-apt:5.0.0:jakarta")

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,17 +1,23 @@
-version: '3'
+version: '3.8'
 services:
-  mysql:
-    image: mysql:8.0
-    ports:
-      - "3306:3306"
+  zookeeper:
+    image: confluentinc/cp-zookeeper:latest
+    container_name: zookeeper
     environment:
-      - MYSQL_ROOT_PASSWORD=root
-      - MYSQL_USER=application
-      - MYSQL_PASSWORD=application
-      - MYSQL_DATABASE=hhplus
-    volumes:
-      - ./data/mysql/:/var/lib/mysql
+      ZOOKEEPER_CLIENT_PORT: 2181
+      ZOOKEEPER_TICK_TIME: 2000
+    ports:
+      - "2181:2181"
 
-networks:
-  default:
-    driver: bridge
+  kafka:
+    image: confluentinc/cp-kafka:latest
+    container_name: kafka
+    depends_on:
+      - zookeeper
+    ports:
+      - "9092:9092"
+    environment:
+      KAFKA_BROKER_ID: 1
+      KAFKA_ZOOKEEPER_CONNECT: "zookeeper:2181"  # ✅ Zookeeper 연결
+      KAFKA_ADVERTISED_LISTENERS: PLAINTEXT://localhost:9092
+      KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR: 1

--- a/src/test/java/hhplus/ecommerce/TestContainersConfiguration.java
+++ b/src/test/java/hhplus/ecommerce/TestContainersConfiguration.java
@@ -13,8 +13,8 @@ public class TestContainersConfiguration {
     static {
         MYSQL_CONTAINER = new MySQLContainer<>(DockerImageName.parse("mysql:8.0"))
                 .withDatabaseName("hhplus")
-                .withUsername("root")
-                .withPassword("1234");
+                .withUsername("test")
+                .withPassword("test");
         REDIS_CONTAINER = new GenericContainer<>(DockerImageName.parse("redis:6.2"))
                 .withExposedPorts(6379);
 
@@ -27,6 +27,8 @@ public class TestContainersConfiguration {
         //redis 설정
         System.setProperty("spring.redis.host", REDIS_CONTAINER.getHost());
         System.setProperty("spring.redis.port", REDIS_CONTAINER.getMappedPort(6379).toString());
+        //Kafka 환경 변수 설정
+        System.setProperty("spring.kafka.bootstrap-servers", "localhost:9092");
         // JPA 설정 추가
         System.setProperty("spring.jpa.hibernate.ddl-auto", "create");
         System.setProperty("spring.jpa.show-sql", "true");

--- a/src/test/java/hhplus/ecommerce/config/KafkaIntegrationTest.java
+++ b/src/test/java/hhplus/ecommerce/config/KafkaIntegrationTest.java
@@ -1,0 +1,42 @@
+package hhplus.ecommerce.config;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.kafka.annotation.EnableKafka;
+import org.springframework.kafka.annotation.KafkaListener;
+import org.springframework.kafka.core.KafkaTemplate;
+
+import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.TimeUnit;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@SpringBootTest
+@EnableKafka
+public class KafkaIntegrationTest {
+    @Autowired
+    private KafkaTemplate<String, String> kafkaTemplate;
+
+    private final BlockingQueue<String> messages = new LinkedBlockingQueue<>(); //카프카의 메시지수신은 비동기적으로 실행되기 때문에 BlockingQueue 적절하다고 판단
+
+    @KafkaListener(topics = "name", groupId = "test-group")
+    public void consume(String message) {
+        messages.add(message);
+    }
+
+    @Test
+    public void 카프카연동테스트_name토픽에서_기만석_반환() throws InterruptedException {
+        // given
+        String topic = "name";
+        String message = "기만석";
+
+        // when
+        kafkaTemplate.send(topic, message);
+
+        // then
+        String receivedMessage = messages.poll(5, TimeUnit.SECONDS);
+        assertThat(receivedMessage).isEqualTo(message);
+    }
+}


### PR DESCRIPTION
### **커밋 링크**
로컬에서 docker-compose.yml로 docker 컨테이너 생성 후 카프카 테스트 진행 했습니다!

- Kafka 연동 확인 테스트 : d021409
- Kafka와 Spring 연결 설정 : 02975bf

---
### **리뷰 포인트(질문)**

- 리뷰 포인트 1
  - @KafkaListener는 비동기적으로 실행되기 때문에 언제 메시지가 소비되었는지 정확히 알 수 없어 BlockingQueue 자료구조를 사용해 테스트를 구현하였습니다. 적절한 방법인지 궁금합니다!

---
### **이번주 KPT 회고**

### Keep
<!-- 유지해야 할 좋은 점 -->
- 코드 작성 전 전체적인 큰 그림을 그리고 시작하기. (필기를 위한 아이패드가 필요할 것 같다...^^)
### Problem
<!--개선이 필요한 점-->
- 카프카에 동작원리나 개념등을 딥다이브 하지 못했다고 생각합니다.. 추후에 깊은 학습이 필요할 것 같습니다.
### Try
<!-- 새롭게 시도할 점 -->
- 긍정적으로 생각하기